### PR TITLE
Update README env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Create an `.env.local` file with your Gemini API key:
+
+   ```env
+   GEMINI_API_KEY=<your key>
+   ```
+
+   During development Vite maps `GEMINI_API_KEY` to `process.env.API_KEY` so it can be accessed in the code.
 3. Run the app:
    `npm run dev`


### PR DESCRIPTION
## Summary
- document how GEMINI_API_KEY is mapped to `process.env.API_KEY`
- add instructions for creating `.env.local`

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_6842ce47e0408323aa6b86e4b2b9734f